### PR TITLE
Do not always import terminal_server module if not needed

### DIFF
--- a/startGUI.py
+++ b/startGUI.py
@@ -14,7 +14,6 @@ from qt import *
 import BlissFramework
 from BlissFramework import GUISupervisor
 from BlissFramework.Utils import ErrorHandler
-from BlissFramework.Utils import terminal_server
 from BlissFramework.Utils import GUILogHandler
 
 from HardwareRepository import HardwareRepository
@@ -60,6 +59,7 @@ def run(GUIConfigFile=None):
             sys.exit(1)
 
     if opts.webServerPort:
+        from BlissFramework.Utils import terminal_server
         interpreter = terminal_server.InteractiveInterpreter()
         terminal_server.set_interpreter(interpreter) 
         gevent.spawn(terminal_server.serve_forever, opts.webServerPort)


### PR DESCRIPTION
Moved import where it is really needed, in order to prevent errors if bottle or other dependencies are not installed