### PR TITLE
Add option to startGUI to choose PyQt binding

### DIFF
--- a/Bricks/Qt4_KappaPhiMotorsBrick.py
+++ b/Bricks/Qt4_KappaPhiMotorsBrick.py
@@ -57,21 +57,21 @@ class Qt4_KappaPhiMotorsBrick(BlissWidget):
 
         # Graphic elements-----------------------------------------------------
 
-        _main_groupbox = QtGui.QGroupBox(self)
-        self.kappa_dspinbox = QtGui.QDoubleSpinBox(_main_groupbox)
+        _main_groupbox = QGroupBox(self)
+        self.kappa_dspinbox = QDoubleSpinBox(_main_groupbox)
         self.kappa_dspinbox.setRange(-360, 360)
-        self.kappaphi_dspinbox = QtGui.QDoubleSpinBox(_main_groupbox)
+        self.kappaphi_dspinbox = QDoubleSpinBox(_main_groupbox)
         self.kappaphi_dspinbox.setRange(-360, 360)
-        self.step_cbox = QtGui.QComboBox(_main_groupbox)
+        self.step_cbox = QComboBox(_main_groupbox)
         self.step_button_icon = Qt4_Icons.load_icon('TileCascade2')
-        self.close_button = QtGui.QPushButton("Close", _main_groupbox)
-        self.stop_button = QtGui.QPushButton(_main_groupbox)
+        self.close_button = QPushButton("Close", _main_groupbox)
+        self.stop_button = QPushButton(_main_groupbox)
 
         # Layout --------------------------------------------------------------
-        _main_groupbox_hlayout = QtGui.QHBoxLayout(_main_groupbox)
-        _main_groupbox_hlayout.addWidget(QtGui.QLabel("Kappa:", _main_groupbox)) 
+        _main_groupbox_hlayout = QHBoxLayout(_main_groupbox)
+        _main_groupbox_hlayout.addWidget(QLabel("Kappa:", _main_groupbox)) 
         _main_groupbox_hlayout.addWidget(self.kappa_dspinbox)
-        _main_groupbox_hlayout.addWidget(QtGui.QLabel("Phi:", _main_groupbox))
+        _main_groupbox_hlayout.addWidget(QLabel("Phi:", _main_groupbox))
         _main_groupbox_hlayout.addWidget(self.kappaphi_dspinbox)
         _main_groupbox_hlayout.addWidget(self.step_cbox)
         _main_groupbox_hlayout.addWidget(self.close_button)
@@ -79,7 +79,7 @@ class Qt4_KappaPhiMotorsBrick(BlissWidget):
         _main_groupbox_hlayout.setSpacing(2)
         _main_groupbox_hlayout.setContentsMargins(0, 0, 0, 0)
 
-        _main_hlayout = QtGui.QHBoxLayout(self)
+        _main_hlayout = QHBoxLayout(self)
         _main_hlayout.addWidget(_main_groupbox)
         _main_hlayout.setSpacing(2)
         _main_hlayout.setContentsMargins(2, 2, 2, 2)
@@ -105,13 +105,13 @@ class Qt4_KappaPhiMotorsBrick(BlissWidget):
        
         #self.stop_button.setSizePolicy(qt.QSizePolicy.Fixed, qt.QSizePolicy.Minimum)
         # Other ---------------------------------------------------------------
-        self.kappa_dspinbox.setAlignment(QtCore.Qt.AlignRight)
+        self.kappa_dspinbox.setAlignment(Qt.AlignRight)
         self.kappa_dspinbox.setFixedWidth(75)
-        self.kappaphi_dspinbox.setAlignment(QtCore.Qt.AlignRight)
+        self.kappaphi_dspinbox.setAlignment(Qt.AlignRight)
         self.kappaphi_dspinbox.setFixedWidth(75)
 
         self.step_cbox.setEditable(True)
-        self.step_cbox.setValidator(QtGui.QDoubleValidator(0, 360, 5, self.step_cbox))
+        self.step_cbox.setValidator(QDoubleValidator(0, 360, 5, self.step_cbox))
         self.step_cbox.setDuplicatesEnabled(False)
 
         self.stop_button.setIcon(Qt4_Icons.load_icon('Stop2'))
@@ -170,12 +170,12 @@ class Qt4_KappaPhiMotorsBrick(BlissWidget):
     def kappa_value_edited(self, text):
         Qt4_widget_colors.set_widget_color(self.kappa_dspinbox.lineEdit(),
                                            Qt4_widget_colors.LINE_EDIT_CHANGED,
-                                           QtGui.QPalette.Base)
+                                           QPalette.Base)
 
     def kappaphi_value_edited(self, text):
         Qt4_widget_colors.set_widget_color(self.kappaphi_dspinbox.lineEdit(),
                                            Qt4_widget_colors.LINE_EDIT_CHANGED,
-                                           QtGui.QPalette.Base)
+                                           QPalette.Base)
 
     def kappa_value_accepted(self):
         self.diffractometer_hwobj.move_kappa_and_phi(\
@@ -209,11 +209,11 @@ class Qt4_KappaPhiMotorsBrick(BlissWidget):
             Qt4_widget_colors.set_widget_color(\
                 self.kappa_dspinbox.lineEdit(),
                 Qt4_widget_colors.LIGHT_GREEN,
-                QtGui.QPalette.Base)
+                QPalette.Base)
             Qt4_widget_colors.set_widget_color(\
                 self.kappaphi_dspinbox.lineEdit(),
                 Qt4_widget_colors.LIGHT_GREEN,
-                QtGui.QPalette.Base)
+                QPalette.Base)
         else:
             self.kappa_dspinbox.setEnabled(False)
             self.kappaphi_dspinbox.setEnabled(False) 
@@ -222,11 +222,11 @@ class Qt4_KappaPhiMotorsBrick(BlissWidget):
             Qt4_widget_colors.set_widget_color(\
                 self.kappa_dspinbox.lineEdit(),
                 Qt4_widget_colors.LIGHT_YELLOW, 
-                QtGui.QPalette.Base)
+                QPalette.Base)
             Qt4_widget_colors.set_widget_color(\
                 self.kappaphi_dspinbox.lineEdit(),
                 Qt4_widget_colors.LIGHT_YELLOW,
-                QtGui.QPalette.Base)
+                QPalette.Base)
 
     def go_to_step(self, step_index):
         """
@@ -262,7 +262,7 @@ class Qt4_KappaPhiMotorsBrick(BlissWidget):
         Return.   : 
         """
         Qt4_widget_colors.set_widget_color(self.step_cbox.lineEdit(),
-             QtCore.Qt.white, QtGui.QPalette.Base)
+             Qt.white, QPalette.Base)
 
     def step_edited(self, step):
         """
@@ -272,20 +272,20 @@ class Qt4_KappaPhiMotorsBrick(BlissWidget):
         """
         Qt4_widget_colors.set_widget_color(self.step_cbox,
                                            Qt4_widget_colors.LINE_EDIT_CHANGED,
-                                           QtGui.QPalette.Button)
+                                           QPalette.Button)
 
-class SpinBoxEvent(QtCore.QObject):
-    returnPressedSignal = QtCore.pyqtSignal()
-    contextMenuSignal = QtCore.pyqtSignal()
+class SpinBoxEvent(QObject):
+    returnPressedSignal = pyqtSignal()
+    contextMenuSignal = pyqtSignal()
 
     def eventFilter(self,  obj,  event):
-        if event.type() == QtCore.QEvent.KeyPress:
-            if event.key() in [QtCore.Qt.Key_Enter,
-                               QtCore.Qt.Key_Return]:
+        if event.type() == QEvent.KeyPress:
+            if event.key() in [Qt.Key_Enter,
+                               Qt.Key_Return]:
                 self.returnPressedSignal.emit()
 
-        elif event.type() == QtCore.QEvent.MouseButtonRelease:
+        elif event.type() == QEvent.MouseButtonRelease:
             self.returnPressedSignal.emit()
-        elif event.type() == QtCore.QEvent.ContextMenu:
+        elif event.type() == QEvent.ContextMenu:
             self.contextMenuSignal.emit()
         return False

--- a/Bricks/Qt4_LightControlBrick.py
+++ b/Bricks/Qt4_LightControlBrick.py
@@ -45,10 +45,10 @@ class Qt4_LightControlBrick(Qt4_MotorSpinBoxBrick.Qt4_MotorSpinBoxBrick):
         self.addProperty('icons', 'string', '')
         self.addProperty('out_delta', 'string', '')
 
-        self.light_off_button=QtGui.QPushButton("",self.extra_button_box)
+        self.light_off_button=QPushButton("",self.extra_button_box)
         self.light_off_button.setIcon(Qt4_Icons.load_icon('BulbDelete'))
 
-        self.light_on_button=QtGui.QPushButton("",self.extra_button_box)
+        self.light_on_button=QPushButton("",self.extra_button_box)
         self.light_on_button.setIcon(Qt4_Icons.load_icon('BulbCheck'))
 
         self.light_on_button.clicked.connect(self.lightButtonOffClicked)
@@ -64,8 +64,8 @@ class Qt4_LightControlBrick(Qt4_MotorSpinBoxBrick.Qt4_MotorSpinBoxBrick):
         self.light_off_button.setToolTip("Switches off the light and sets the intensity to zero")
         self.light_on_button.setToolTip("Switches on the light and sets the intensity back to the previous setting")        
 
-        self.light_off_button.setSizePolicy(QtGui.QSizePolicy.Fixed, QtGui.QSizePolicy.Minimum)
-        self.light_on_button.setSizePolicy(QtGui.QSizePolicy.Fixed, QtGui.QSizePolicy.Minimum)
+        self.light_off_button.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Minimum)
+        self.light_on_button.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Minimum)
 
 
     ### Light off pressed: switch off lamp and set out the wago

--- a/Bricks/Qt4_MultipleMotorsBrick.py
+++ b/Bricks/Qt4_MultipleMotorsBrick.py
@@ -64,19 +64,19 @@ class Qt4_MultipleMotorsBrick(BlissWidget):
         # Slots ---------------------------------------------------------------
 
         # Graphic elements ----------------------------------------------------
-        self.main_group_box = QtGui.QGroupBox(self)
-        self.enable_motors_buttons = QtGui.QPushButton('Enable', self.main_group_box)
-        self.disable_motors_buttons = QtGui.QPushButton('Disable', self.main_group_box)
+        self.main_group_box = QGroupBox(self)
+        self.enable_motors_buttons = QPushButton('Enable', self.main_group_box)
+        self.disable_motors_buttons = QPushButton('Disable', self.main_group_box)
 
         # Layout -------------------------------------------------------------- 
         if self['alignment'] == 'horizontal':
-            self.main_groupbox_hlayout = QtGui.QHBoxLayout(self.main_group_box)
+            self.main_groupbox_hlayout = QHBoxLayout(self.main_group_box)
         else:
-            self.main_groupbox_hlayout = QtGui.QVBoxLayout(self.main_group_box)
+            self.main_groupbox_hlayout = QVBoxLayout(self.main_group_box)
         self.main_groupbox_hlayout.setSpacing(2)
         self.main_groupbox_hlayout.setContentsMargins(0, 0, 0, 0)
 
-        self.main_hlayout = QtGui.QHBoxLayout(self)
+        self.main_hlayout = QHBoxLayout(self)
         self.main_hlayout.addWidget(self.main_group_box)
         self.main_hlayout.setSpacing(2)
         self.main_hlayout.setContentsMargins(2, 2, 2, 2)
@@ -133,7 +133,7 @@ class Qt4_MultipleMotorsBrick(BlissWidget):
         elif property_name == 'predefinedPositions':
             self.predefined_positions_list = new_value.split()
             for predefined_position in self.predefined_positions_list:
-                temp_position_button = QtGui.QPushButton(predefined_position, self.main_group_box)
+                temp_position_button = QPushButton(predefined_position, self.main_group_box)
                 self.main_groupbox_hlayout.addWidget(temp_position_button)
                 temp_position_button.clicked.connect(lambda: \
                      self.predefined_position_clicked(predefined_position))

--- a/Bricks/Qt4_StatusBarBrick.py
+++ b/Bricks/Qt4_StatusBarBrick.py
@@ -32,10 +32,10 @@ __category__ = "General"
 
 
 class Qt4_StatusBarBrick(BlissWidget):
-    STATES = { "Unknown": QtGui.QWidget.gray,\
+    STATES = { "Unknown": QWidget.gray,\
         "Disconnected": Qt4_widget_colors.LIGHT_RED,\
-        "Connected": QtGui.QColor(255,165,0),\
-        "Busy": QtGui.QWidget.yellow,\
+        "Connected": QColor(255,165,0),\
+        "Busy": QWidget.yellow,\
         "Ready": Qt4_widget_colors.LIGHT_GREEN }
 
     def __init__(self, *args):

--- a/Bricks/Qt4_ToolsBrick.py
+++ b/Bricks/Qt4_ToolsBrick.py
@@ -62,7 +62,7 @@ class Qt4_ToolsBrick(BlissWidget):
         # Other ---------------------------------------------------------------
 
     def run(self):
-        self.tools_menu = QtGui.QMenu("Tools", self)
+        self.tools_menu = QMenu("Tools", self)
         self.tools_menu.addSeparator()
         BlissWidget._menuBar.insert_menu(self.tools_menu, 2)
         self.init_tools()

--- a/Qt4_BaseComponents.py
+++ b/Qt4_BaseComponents.py
@@ -162,7 +162,7 @@ class SignalSlotFilter:
             s(*args)
 
 
-class BlissWidget(QFrame, Connectable.Connectable):
+class BlissWidget(Connectable.Connectable, QFrame):
     (INSTANCE_ROLE_UNKNOWN, INSTANCE_ROLE_SERVER, INSTANCE_ROLE_SERVERSTARTING,
      INSTANCE_ROLE_CLIENT, INSTANCE_ROLE_CLIENTCONNECTING) = (0, 1, 2, 3, 4)
     (INSTANCE_MODE_UNKNOWN, INSTANCE_MODE_MASTER, INSTANCE_MODE_SLAVE) = (0, 1, 2)
@@ -782,7 +782,7 @@ class BlissWidget(QFrame, Connectable.Connectable):
         self.defineSlot('enable_widget', ())
         self.defineSlot('disable_widget', ())
 
-        #self.run_mode = QtGui.QPushButton("Run mode", self)
+        #self.run_mode = QPushButton("Run mode", self)
 
     def __run(self):
         """
@@ -859,8 +859,8 @@ class BlissWidget(QFrame, Connectable.Connectable):
         if instanceFilter:
             self.connectSignalSlotFilter(_sender,
                                          pysignal and \
-                                         QtCore.SIGNAL(signal) or \
-                                         QtCore.SIGNAL(signal),
+                                         SIGNAL(signal) or \
+                                         SIGNAL(signal),
                                          slot, shouldCache)
         else:
             #Porting to Qt5
@@ -1235,11 +1235,11 @@ def ComboBoxActivated(self, index, lines):
                 else:
                     self.insertItem(line)
                     self.setCurrentItem(i)
-                    self.activated[QString].emit(line)
+                    self.activated[str].emit(line)
                     self.activated[int].emit(i)
                 i += 1
     self.setCurrentItem(index)
-    self.activated[QString].emit(self.currentText())
+    self.activated[str].emit(self.currentText())
     self.activated[int].emit(index)
 
 def SpinBoxEditorTextChanged(self, text):

--- a/Qt4_BaseLayoutItems.py
+++ b/Qt4_BaseLayoutItems.py
@@ -178,7 +178,7 @@ class WindowCfg(ContainerCfg):
 
         self.signals.update({"isShown": (),
                              "isHidden": (),
-                             "enableExpertMode": (),
+                             "enableExpertModeSignal": (),
                              "quit":()})
         self.slots.update({"show": (),
                            "hide": (),

--- a/Qt4_GUIBuilder.py
+++ b/Qt4_GUIBuilder.py
@@ -82,7 +82,7 @@ class CustomListWidget(QListWidget):
 class GUITreeWidget(QTreeWidget):
     """Gui config tree"""
 
-    dragDropSignal = pyqtSignal()
+    dragDropSignal = pyqtSignal(object, object)
 
     def __init__(self, *args):
         """__init__ method"""
@@ -115,7 +115,7 @@ class GUITreeWidget(QTreeWidget):
 
         self.drag_target_item = self.itemAt(event.pos())
         if self.drag_source_item and self.drag_target_item:
-            self.dragDropSignal.connect(self.drag_source_item,
+            self.dragDropSignal.emit(self.drag_source_item,
                                         self.drag_target_item)
             self.drag_source_item = None
         event.accept()
@@ -302,7 +302,7 @@ class ToolboxWidget(QWidget):
 
             for brick_name, directory_name, description in bricks_list:
                 brick_list_widget_item = QListWidgetItem(\
-                     QString(self.get_brick_text_label(brick_name)),
+                     self.get_brick_text_label(brick_name),
                      bricks_listwidget)
                 bricks_listwidget.addToolTip(brick_list_widget_item,
                                              description)
@@ -395,7 +395,7 @@ class ToolButton(QToolButton):
 
         if tooltip is not None:
             self.setToolTip(tooltip)
-            #QtGui.QToolTip.add(self, tooltip)
+            #QToolTip.add(self, tooltip)
 
         self.setSizePolicy(QSizePolicy.Fixed,
                            QSizePolicy.Fixed)
@@ -405,12 +405,12 @@ class GUIEditorWindow(QWidget):
     """Gui editor window"""
 
     editPropertiesSignal = pyqtSignal(object)
-    newItemSignal = pyqtSignal(object, 'PyQt_PyObject')
-    drawPreviewSignal = pyqtSignal('PyQt_PyObject', int, list, 'PyQt_PyObject')
-    updatePreviewSignal = pyqtSignal('PyQt_PyObject', 'PyQt_PyObject', 'PyQt_PyObject', 'PyQt_PyObject')
-    addWidgetSignal = pyqtSignal('PyQt_PyObject', 'PyQt_PyObject')
+    newItemSignal = pyqtSignal(object, object)
+    drawPreviewSignal = pyqtSignal(object, int, list, object)
+    updatePreviewSignal = pyqtSignal(object, object, object, object)
+    addWidgetSignal = pyqtSignal(object, object)
     removeWidgetSignal = pyqtSignal(object,object)
-    moveWidgetSignal = pyqtSignal()
+    moveWidgetSignal = pyqtSignal(object, object)
     showProperyEditorWindowSignal = pyqtSignal()
     hidePropertyEditorWindowSignal = pyqtSignal()
     showPreviewSignal = pyqtSignal()
@@ -614,8 +614,8 @@ class GUIEditorWindow(QWidget):
         """Appends an item to the tree"""
 
         new_treewidget_item = QTreeWidgetItem(parent_item)
-        new_treewidget_item.setText(0, QString(str(column1_text)))
-        new_treewidget_item.setText(1, QString(str(column2_text)))
+        new_treewidget_item.setText(0, str(column1_text))
+        new_treewidget_item.setText(1, str(column2_text))
         new_treewidget_item.setExpanded(True)
         self.tree_widget.setDragEnabled(True)
         self.tree_widget.setAcceptDrops(True)
@@ -687,7 +687,7 @@ class GUIEditorWindow(QWidget):
     def prepare_window_preview(self, item_name, item_cfg=None, selected_item=""):
         """Prepares window"""
 
-        item_list = self.tree_widget.findItems(QString(item_name),
+        item_list = self.tree_widget.findItems(str(item_name),
                                                Qt.MatchRecursive,
                                                0)
         item = item_list[0]
@@ -939,7 +939,7 @@ class GUIEditorWindow(QWidget):
            Refreshes property table
         """
 
-        item = self.tree_widget.findItems(QString(item_name),
+        item = self.tree_widget.findItems(str(item_name),
                                           Qt.MatchRecursive, 0)
         if item is not None:
             self.tree_widget.setCurrentItem(item[0])
@@ -1061,7 +1061,7 @@ class GUIEditorWindow(QWidget):
 
                 if new_parent is not None:
                     new_parent_item_list = self.tree_widget.findItems(\
-                         QString(new_parent),
+                         str(new_parent),
                          Qt.MatchRecursive, 0)
                     new_parent_item = new_parent_item_list[0]
 
@@ -1077,7 +1077,7 @@ class GUIEditorWindow(QWidget):
 
                 if new_parent is not None:
                     new_parent_item_list = self.tree_widget.findItems(\
-                         QString(new_parent),
+                         str(new_parent),
                          Qt.MatchRecursive, 0)
                     new_parent_item = new_parent_item_list[0]
 

--- a/Qt4_startGUI.py
+++ b/Qt4_startGUI.py
@@ -114,6 +114,10 @@ def run(gui_config_file=None):
                            "cde, plastique, windowsxp, or macintosh)",
                       dest='appStyle', default=None)
 
+    parser.add_option('', '--pyqt4', action='store_true', default=None)
+    parser.add_option('', '--pyqt5', action='store_true', default=None)
+    parser.add_option('', '--pyside', action='store_true', default=None)
+
     (opts, args) = parser.parse_args()
 
     if len(args) >= 1:
@@ -256,9 +260,13 @@ def run(gui_config_file=None):
     logging.getLogger().info("Starting MXCuBE v%s" % str(__version__))
     logging.getLogger().info("Qt4 GUI file: %s" % (gui_config_file or "unnamed"))
     logging.getLogger().info("Hardware repository: %s" % hwr_server)
-    logging.getLogger().info("System info: Python %s - Qt %s - PyQt %s on %s" % \
-       (platform.python_version(), QT_VERSION_STR, 
-        PYQT_VERSION_STR, platform.system()))
+    logging.getLogger().info("System info: Python %s on %s" %(platform.python_version(), platform.system()))
+    logging.getLogger().info("    - Qt %s - %s %s" % \
+                 ("%d.%d.%d" % tuple(qt_version_no), qt_variant, "%d.%d.%d" % tuple(pyqt_version_no)) )
+    if mpl_imported:
+        logging.getLogger().info("    - Matplotlib %s - " % "%d.%d.%d" % tuple(mpl_version_no))
+    else:
+        logging.getLogger().info("    - Matplotlib not available")
     logging.getLogger().info("---------------------------------------------------------------------------------")
 
     QApplication.setDesktopSettingsAware(False)

--- a/QtImport.py
+++ b/QtImport.py
@@ -105,6 +105,8 @@ elif '--pyside' in sys.argv:
     qt_variant = 'PySide'
 elif '--pyqt4' in sys.argv:
     qt_variant = 'PyQt4'
+elif '--pyqt3' in sys.argv:
+    qt_variant = 'PyQt3'
 
 #
 # PyQt5 
@@ -116,40 +118,17 @@ if (qt_variant == 'PyQt5') or (qt_variant is None and not qt_imported):
         from PyQt5.QtWidgets import *
         from PyQt5.QtPrintSupport import *
         from PyQt5.uic import *
+        try:
+            from PyQt5.QtSvg import *
+        except:
+            print("QtSvg is not imported. It maybe needs to be installed")
 
         getQApp = QCoreApplication.instance
 
         qt_imported = True
         qt_variant = "PyQt5"
         qt_version_no = list(map(int,QT_VERSION_STR.split(".")))
-    except:
-        pass
-#
-# PySide
-#
-if (qt_variant == 'PySide') or (qt_variant is None and not qt_imported):
-    #
-    # Maybe you want to try PySide
-    #
-    try:
-        from PySide.QtCore import *
-        from PySide.QtGui import *
-        from PySide.QtUiTools import *
-        from PySide import __version_info__
-
-        pyqtSignal = Signal
-        qt_imported = True
-        qt_variant = "PySide"
-        getQApp = QCoreApplication.instance
-        qt_version_no = __version_info__[:3]
-        def loadUi(filename, parent=None):
-            loader = QUiLoader()
-            uifile = QFile(uifilename)
-            uifile.open(QFile.ReadOnly)
-            ui = loader.load(uifile, parent)
-            uifile.close()
-            return ui
-
+        pyqt_version_no = list(map(int,PYQT_VERSION_STR.split(".")))[:3]
     except:
         pass
 
@@ -158,7 +137,7 @@ if (qt_variant == 'PySide') or (qt_variant is None and not qt_imported):
 #
 if (qt_variant == 'PyQt4') or (qt_variant is None and not qt_imported):
     #
-    # Finally try PyQt4 
+    # Maybe it is PyQt4 that you want
     #
 
     # force api 2 (so that the api is common for all pyqt versions)
@@ -181,6 +160,7 @@ if (qt_variant == 'PyQt4') or (qt_variant is None and not qt_imported):
         from PyQt4.QtCore import *
         from PyQt4.QtGui import *
         from PyQt4.uic import *
+        from PyQt4.QtSvg import *
         
         def getQApp():
             return qApp
@@ -188,6 +168,41 @@ if (qt_variant == 'PyQt4') or (qt_variant is None and not qt_imported):
         qt_imported = True
         qt_variant = "PyQt4"
         qt_version_no = list(map(int,QT_VERSION_STR.split(".")))
+        pyqt_version_no = list(map(int,PYQT_VERSION_STR.split(".")))[:3]
+    except:
+        pass
+
+#
+# PySide
+#
+if (qt_variant == 'PySide') or (qt_variant is None and not qt_imported):
+    #
+    # Finally try PySide (not fully tested)
+    #
+    try:
+        from PySide import __version_info__ 
+        pyqt_version_no = __version_info__[:3]
+        from PySide.QtCore import __version_info__
+        qt_version_no = __version_info__[:3]
+
+        from PySide.QtCore import *
+        from PySide.QtGui import *
+        from PySide.QtUiTools import *
+        from PySide.QtSvg import *
+
+        pyqtSignal = Signal
+        pyqtSlot = Slot
+        qt_imported = True
+        qt_variant = "PySide"
+        getQApp = QCoreApplication.instance
+        def loadUi(filename, parent=None):
+            loader = QUiLoader()
+            uifile = QFile(uifilename)
+            uifile.open(QFile.ReadOnly)
+            ui = loader.load(uifile, parent)
+            uifile.close()
+            return ui
+
     except:
         pass
 
@@ -216,12 +231,13 @@ if mpl_imported:
         matplotlib.use("Qt4Agg")
 
 if qt_imported:
-    print("Using PyQt:  %s, version: %s" % (qt_variant, "%d.%d.%d" % tuple(qt_version_no)))
+    print("Using PyQt:  %s" % (qt_variant))
+    print("   qt version: %s / pyqt version: %s" % ("%d.%d.%d" % tuple(qt_version_no), "%d.%d.%d" % tuple(pyqt_version_no)))
 else:
     print("Cannot import PyQt")
 
 if mpl_imported:
-    print("Matplotlib:  %s, version: %s" % (qt_variant, "%d.%d.%d" % tuple(mpl_version_no)))
+    print("Matplotlib version: %s" % "%d.%d.%d" % tuple(mpl_version_no))
 else:
     print("Cannot import matplotlib")
 

--- a/Utils/Connectable.py
+++ b/Utils/Connectable.py
@@ -1,6 +1,6 @@
-from QtImport import *
 
-class Connectable:
+class Connectable(object):
+
     def __init__(self):
         self.__signal = {}
         self.__slot = {}

--- a/Utils/Qt4_ConnectionEditor.py
+++ b/Utils/Qt4_ConnectionEditor.py
@@ -23,7 +23,6 @@ from QtImport import *
 
 from BlissFramework import Qt4_Icons
 
-
 class Qt4_ConnectionEditor(QDialog):
     """Connection editor"""
 

--- a/Utils/Qt4_ErrorHandler.py
+++ b/Utils/Qt4_ErrorHandler.py
@@ -79,8 +79,7 @@ class __Handler:
         Descript. :
         """
         if type == KeyboardInterrupt:
-          #qt.qApp.quit()
-          QApplication.quit()
+          getQApp().quit()
           return
         try: 
             exception = traceback.format_exception(type, value, tb)

--- a/Utils/Qt4_GUIDisplay.py
+++ b/Utils/Qt4_GUIDisplay.py
@@ -530,7 +530,7 @@ class WindowDisplayWidget(QScrollArea):
         """Tab widget"""
 
         notebookPageChangedSignal = pyqtSignal(str)
-        tabChangedSignal = pyqtSignal(int, 'PyQt_PyObject')
+        tabChangedSignal = pyqtSignal(int, object)
         
 
         def __init__(self, *args, **kwargs):

--- a/Utils/Qt4_ProcedureWidgets.py
+++ b/Utils/Qt4_ProcedureWidgets.py
@@ -48,7 +48,7 @@ class VerticalSpacer(QWidget):
 
 class ProcedurePanel(QWidget):
     """Container for Procedure widgets"""
-    def __init__(self, parent, orientation = QtCore.Qt.Vertical):
+    def __init__(self, parent, orientation = Qt.Vertical):
         """Constructor
 
         parent -- the parent QObject
@@ -65,7 +65,7 @@ class ProcedurePanel(QWidget):
             #
             self.setProcedure(parent.getProcedure())
     
-        if orientation == QtCore.Qt.Vertical:
+        if orientation == Qt.Vertical:
             ProcedureBoxLayout(self, QBoxLayout.Down, 10, 5)
         else:
             ProcedureBoxLayout(self, QBoxLayout.LeftToRight, 10, 5)
@@ -89,7 +89,8 @@ class ProcedurePanel(QWidget):
         
             self.procedure = weakref.ref(proc)()
 
-            QtCore.QObject.connect(HardwareRepository.emitter(self.procedure), SIGNAL('replyArrived'), self.replyArrived)
+            self.connect( HardwareRepository.emitter(self.procedure), 'replyArrived', self.replyArrived)
+            #QtCore.QObject.connect(HardwareRepository.emitter(self.procedure), SIGNAL('replyArrived'), self.replyArrived)
 
 
     def getProcedure(self):
@@ -348,10 +349,14 @@ class FloatEntryField(ProcedureEntryField):
         self.cmdOK.setPixmap(Qt4_Icons.load('button_ok_small')) #QPixmap(Icons.okXPM))
         self.cmdCancel.setPixmap(Qt4_Icons.load('button_cancel_small')) #QPixmap(Icons.cancelXPM))
         
-        QObject.connect(self.textbox, SIGNAL('returnPressed()'), self.valueChanged)
-        QObject.connect(self.textbox, SIGNAL('textChanged( const QString & )'), self.valueChanging)
-        QObject.connect(self.cmdOK, SIGNAL('clicked()'), self.valueChanged)
-        QObject.connect(self.cmdCancel, SIGNAL('clicked()'), self.cancelClicked)
+        self.textbox.returnPressed.connect(self.valueChanged)
+        self.textbox.textChanged.connect(self.valueChanging)
+        self.cmdOK.clicked.connect(self.valueChanged)
+        self.cmdCancel.clicked.connect(self.cancelClicked)
+        #QObject.connect(self.textbox, SIGNAL('returnPressed()'), self.valueChanged)
+        #QObject.connect(self.textbox, SIGNAL('textChanged( const QString & )'), self.valueChanging)
+        #QObject.connect(self.cmdOK, SIGNAL('clicked()'), self.valueChanged)
+        #QObject.connect(self.cmdCancel, SIGNAL('clicked()'), self.cancelClicked)
 
         self.cmdCancel.setEnabled(False)
         self.cmdOK.setEnabled(True)
@@ -460,10 +465,14 @@ class TextEntryField(ProcedureEntryField):
         self.cmdOK.setPixmap(Qt4_Icons.load('button_ok_small')) #QPixmap(Icons.okXPM))
         self.cmdCancel.setPixmap(Qt4_Icons.load('button_cancel_small')) #QPixmap(Icons.cancelXPM))
         
-        QObject.connect(self.textbox, SIGNAL('textChanged( const QString & )'), self.valueChanging)
-        QObject.connect(self.textbox, SIGNAL('returnPressed()'), self.valueChanged)
-        QObject.connect(self.cmdOK, SIGNAL('clicked()'), self.valueChanged)
-        QObject.connect(self.cmdCancel, SIGNAL('clicked()'), self.cancelClicked)
+        self.textbox.textChanged.connect(self.valueChanging)
+        self.textbox.returnPressed.connect(self.valueChanged)
+        self.cmdOK.clicked.connect(self.valueChanged)
+        self.cmdCancel.clicked.connect(self.cancelClicked)
+        #QObject.connect(self.textbox, SIGNAL('textChanged( const QString & )'), self.valueChanging)
+        #QObject.connect(self.textbox, SIGNAL('returnPressed()'), self.valueChanged)
+        #QObject.connect(self.cmdOK, SIGNAL('clicked()'), self.valueChanged)
+        #QObject.connect(self.cmdCancel, SIGNAL('clicked()'), self.cancelClicked)
 
         self.cmdCancel.setEnabled(False)
         self.cmdOK.setEnabled(True)
@@ -642,7 +651,7 @@ class ScanConfigurationTable(QTableWidget):
     def __init__(self, parent):
         QTableWidget.__init__(self, parent)
 
-        self.motorsList = QStringList()
+        self.motorsList = []
         self.motors = {}
         self.customColumns = {}
 
@@ -691,7 +700,7 @@ class ScanConfigurationTable(QTableWidget):
 
         self.customColumns[c] = {'type':str(type), 'label':str(label), 'opt':opt}
         if self.customColumns[c]['type'] == 'combo':
-            optList = QStringList()
+            optList = []
             
             try:
                 for opt in self.customColumns[c]['opt']:
@@ -720,7 +729,7 @@ class ScanConfigurationTable(QTableWidget):
 
             for col in self.customColumns:
                 if self.customColumns[col]['type'] == 'combo':
-                    optList = QStringList()
+                    optList = []
             
                     try:
                         for opt in self.customColumns[col]['opt']:
@@ -750,7 +759,7 @@ class ScanConfigurationTable(QTableWidget):
     
 
     def setMotors(self, motorSet):
-        self.motorsList = QStringList()
+        self.motorsList = []
         self.motors = {}
         
         #self.motorsList.append('')
@@ -874,7 +883,7 @@ class Table(QTableWidget):
         
         self.customColumns[c] = {'type':str(type), 'label':str(label), 'opt':opt}
         if self.customColumns[c]['type'] == 'combo':
-            optList = QStringList()
+            optList = []
             
             try:
                 for opt in self.customColumns[c]['opt']:
@@ -896,7 +905,7 @@ class Table(QTableWidget):
         for i in range(rows):
             for col in self.customColumns:
                 if self.customColumns[col]['type'] == 'combo':
-                    optList = QStringList()
+                    optList = []
             
                     try:
                         for opt in self.customColumns[col]['opt']:

--- a/Utils/Qt4_PropertyEditor.py
+++ b/Utils/Qt4_PropertyEditor.py
@@ -35,7 +35,7 @@ class Qt4_ConfigurationTable(QTableWidget):
     Descript. :
     """
 
-    propertyChangedSignal = pyqtSignal(str, 'PyQt_PyObject', 'PyQt_PyObject')
+    propertyChangedSignal = pyqtSignal(str, object, object)
 
     def __init__(self, parent):
         """
@@ -149,7 +149,6 @@ class Qt4_ConfigurationTable(QTableWidget):
             else:
                 self.item(row, 1).setCheckState(Qt.Unchecked)
         elif prop.getType() == 'combo':
-            #choicesList = StringList()
             choicesList = []
             choices = prop.getChoices()
             for choice in choices:
@@ -397,7 +396,7 @@ class FileTableItem(QWidget):
         """
         Descript. :
         """
-        new_filename = FileDialog.getOpenFileName(
+        new_filename = QFileDialog.getOpenFileName(
                              self, os.path.dirname(self.filename) or os.getcwd(), 
                              self.file_filter, '', 'Select a file')
         


### PR DESCRIPTION
Complete startup message with matplotlib info and new variables provided by QtImport

Use "object" rather than "PyQt_PyObject" in some signals

Set PyQt4 before as default binding (between PyQt5 and PySide) PySide is not fully tested yet

Correct a few minor issues
     drag and drop not working in GUI Editor fixed
     bug with FileDialog in GUI Property Editor fixed