### PR TITLE
Bug fix - QtImport was incompatible with qt3

### DIFF
--- a/QtImport.py
+++ b/QtImport.py
@@ -252,27 +252,29 @@ if qt_imported and mpl_imported:
         print("  !!! Matplotlib is NOT COMPATIBLE with PyQt !!!")
 """
 
-class RotatedHeaderView(QHeaderView):
-    def __init__(self, parent=None):
-        super(RotatedHeaderView, self).__init__(Qt.Horizontal, parent)
-        self.setMinimumSectionSize(22)
+if qt_variant in ('PyQt4', 'PyQt5', 'PySide'):
+    # QHeaderView is not defined for Qt3, so the import broke without the 'if'
+    class RotatedHeaderView(QHeaderView):
+        def __init__(self, parent=None):
+            super(RotatedHeaderView, self).__init__(Qt.Horizontal, parent)
+            self.setMinimumSectionSize(22)
 
-    def paintSection(self, painter, rect, logicalIndex ):
-        painter.save()
-        # translate the painter such that rotate will rotate around the correct point
-        painter.translate(rect.x()+rect.width(), rect.y())
-        painter.rotate(90)
-        # and have parent code paint at this location
-        newrect = QRect(0,0,rect.height(),rect.width())
-        super(RotatedHeaderView, self).paintSection(painter, newrect, logicalIndex)
-        painter.restore()
+        def paintSection(self, painter, rect, logicalIndex ):
+            painter.save()
+            # translate the painter such that rotate will rotate around the correct point
+            painter.translate(rect.x()+rect.width(), rect.y())
+            painter.rotate(90)
+            # and have parent code paint at this location
+            newrect = QRect(0,0,rect.height(),rect.width())
+            super(RotatedHeaderView, self).paintSection(painter, newrect, logicalIndex)
+            painter.restore()
 
-    def minimumSizeHint(self):
-        size = super(RotatedHeaderView, self).minimumSizeHint()
-        size.transpose()
-        return size
+        def minimumSizeHint(self):
+            size = super(RotatedHeaderView, self).minimumSizeHint()
+            size.transpose()
+            return size
 
-    def sectionSizeFromContents(self, logicalIndex):
-        size = super(RotatedHeaderView, self).sectionSizeFromContents(logicalIndex)
-        size.transpose()
-        return size
+        def sectionSizeFromContents(self, logicalIndex):
+            size = super(RotatedHeaderView, self).sectionSizeFromContents(logicalIndex)
+            size.transpose()
+            return size


### PR DESCRIPTION
Trying to run the qt3 MXCuBE with the latest version broke, because of an error:

```
  File "/root/mxcube/BlissFramework/QtImport.py", line 256, in <module>
    class RotatedHeaderView(QHeaderView):
NameError: name 'QHeaderView' is not defined
```
